### PR TITLE
fix rego version handling

### DIFF
--- a/build.go
+++ b/build.go
@@ -82,7 +82,18 @@ const (
 )
 
 func (v RegoVersion) ToAstRegoVersion() ast.RegoVersion {
-	return ast.RegoVersionFromInt(int(v))
+	switch v {
+	case RegoUndefined:
+		return ast.RegoUndefined
+	case RegoV0:
+		return ast.RegoV0
+	case RegoV0CompatV1:
+		return ast.RegoV0CompatV1
+	case RegoV1:
+		return ast.RegoV1
+	default:
+		return ast.RegoUndefined
+	}
 }
 
 func (v RegoVersion) String() string {


### PR DESCRIPTION
Incorrect usage of OPA ast.RegoVersionFromInt which handle int=1 as ast.RegoV1 and int=0 as ast.RegoV0, but does not handle ast.RegoV0CompatV1

